### PR TITLE
Dashboard - Top 5 Search Terms link issue

### DIFF
--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
@@ -119,7 +119,7 @@ class Mage_CatalogSearch_Model_Resource_Query_Collection extends Mage_Core_Model
             ->distinct(true)
             ->from(
                 array('main_table' => $this->getTable('catalogsearch/search_query')),
-                array('name' => $ifSynonymFor, 'num_results', 'popularity')
+                array('name' => $ifSynonymFor, 'num_results', 'popularity', 'query_id')
             );
         if ($storeIds) {
             $this->addStoreFilter($storeIds);


### PR DESCRIPTION
Go to Dashboard page in Backend and take a look to the following blocks: **Last 5 Search Terms** and **Top 5 Search Terms**. Now place your mouse pointer over a search term in Last 5 Search Terms list and take a look to the URL. Here is the link in my case:

https://www.mydomain.tld/index.php/admin/catalog_search/edit/id/41/key/5874688c27ec9781d42bacfd92420f0e/

Now place your mouse pointer over a search term in Top 5 Search Terms list and take a look to the URL. Here is the link in my case:

https://www.mydomain.tld/index.php/admin/catalog_search/edit/key/5874688c27ec9781d42bacfd92420f0e/

The last link has an issue. Comparing with the first one which redirects correctly to edit the search term this one is opening the page to create a new search query not editing the search term. This is happening because the link has missing two parameters id and id_number between /edit/ ... /key/

This PR fixes this issues.