### PR TITLE
Change default sort in CMS Pages grid

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
@@ -38,7 +38,7 @@ class Mage_Adminhtml_Block_Cms_Page_Grid extends Mage_Adminhtml_Block_Widget_Gri
     {
         parent::__construct();
         $this->setId('cmsPageGrid');
-        $this->setDefaultSort('identifier');
+        $this->setDefaultSort('title');
         $this->setDefaultDir('ASC');
     }
 


### PR DESCRIPTION
This changes the default sort order in CMS Pages grid from column 2 (URL Key) to column 1 (Title)