### PR TITLE
Change default sort in CMS Blocks grid

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
@@ -38,7 +38,7 @@ class Mage_Adminhtml_Block_Cms_Block_Grid extends Mage_Adminhtml_Block_Widget_Gr
     {
         parent::__construct();
         $this->setId('cmsBlockGrid');
-        $this->setDefaultSort('block_identifier');
+        $this->setDefaultSort('title');
         $this->setDefaultDir('ASC');
     }
 


### PR DESCRIPTION
This changes the default sort order in CMS Blocks grid from column 2 (Identifier) to column 1 (Title).

Please note the initial OpenMage code in this file had an issue

```
class Mage_Adminhtml_Block_Cms_Block_Grid extends Mage_Adminhtml_Block_Widget_Grid
{

    public function __construct()
    {
        parent::__construct();
        $this->setId('cmsBlockGrid');
        $this->setDefaultSort('block_identifier');
        $this->setDefaultDir('ASC');
    }
```

The **block_identifier** value doesn't exist. It should be **identifier**.