### PR TITLE
Change default sort in CMS Widgets grid

### DIFF
--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Grid.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Grid.php
@@ -41,7 +41,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Instance_Grid extends Mage_Adminhtml_Bl
     {
         parent::_construct();
         $this->setId('widgetInstanceGrid');
-        $this->setDefaultSort('instance_id');
+        $this->setDefaultSort('title');
         $this->setDefaultDir('ASC');
     }
 


### PR DESCRIPTION
This changes the default sort order in CMS Blocks grid from column 1 (Widget ID) to column 2 (Widget Instance Title).