### PR TITLE
Sort ascending CMS Block list in Categories

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Page.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Page.php
@@ -40,6 +40,7 @@ class Mage_Catalog_Model_Category_Attribute_Source_Page extends Mage_Eav_Model_E
     {
         if (!$this->_options) {
             $this->_options = Mage::getResourceModel('cms/block_collection')
+                ->setOrder('title', 'ASC')
                 ->load()
                 ->toOptionArray();
             array_unshift($this->_options, array('value'=>'', 'label'=>Mage::helper('catalog')->__('Please select a static block ...')));


### PR DESCRIPTION
If you have a lot of CMS blocks like landing pages and you would like to add them to your categories you will have an issue because the list is not ordered ascending. This PR fixes the issue.