### PR TITLE
DDEV command to create/update the administrator account

### DIFF
--- a/.ddev/commands/web/openmage-admin
+++ b/.ddev/commands/web/openmage-admin
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+## ProjectTypes: magento
+## Description: Create/Update OpenMage Admininstrator Account
+## Usage: openmage-admin
+## Example: ddev openmage-admin
+
+read -r -p "Choose your action for the administrator account [Create/Update]: " ACTION
+ACTION=${ACTION,,} # to lower
+
+if [[ "${USE_DEFAULT_FLAG}" ]]; then
+  ADMIN_USER='admin'
+  ADMIN_FIRSTNAME='OpenMage'
+  ADMIN_LASTNAME='Administrator'
+  ADMIN_EMAIL='admin@example.com'
+  ADMIN_PASSWORD='veryl0ngpassw0rd'
+else
+  read -r -p "Admin user [admin]: " ADMIN_USER
+  ADMIN_USER=${ADMIN_USER:-admin}
+  read -r -p "Admin firstname [OpenMage]: " ADMIN_FIRSTNAME
+  ADMIN_FIRSTNAME=${ADMIN_FIRSTNAME:-OpenMage}
+  read -r -p "Admin lastname [Administrator]: " ADMIN_LASTNAME
+  ADMIN_LASTNAME=${ADMIN_LASTNAME:-Administrator}
+  read -r -p "Admin email [admin@example.com]: " ADMIN_EMAIL
+  ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
+  read -r -p "Admin password [veryl0ngpassw0rd]: " ADMIN_PASSWORD
+  ADMIN_PASSWORD=${ADMIN_PASSWORD:-veryl0ngpassw0rd}
+fi
+
+if [[ "${ACTION}" =~ ^(update|u) ]]; then
+  mysql -u db -h db db -e "UPDATE admin_user SET password=CONCAT(MD5('zmQetUQSrQwdbyS1XVDwG9AsfKkgfXAd"${ADMIN_PASSWORD}"'),':zmQetUQSrQwdbyS1XVDwG9AsfKkgfXAd') WHERE username='"${ADMIN_USER}"'"
+  echo "If the account "${ADMIN_USER}" exists it has been updated."
+elif [[ "${ACTION}" =~ ^(create|c) ]]; then
+  if mysql -u db -h db db -e "INSERT INTO admin_user (firstname, lastname, email, username, password) VALUES ('"${ADMIN_FIRSTNAME}"', '"${ADMIN_LASTNAME}"', '"${ADMIN_EMAIL}"', '"${ADMIN_USER}"', CONCAT(MD5('zmQetUQSrQwdbyS1XVDwG9AsfKkgfXAd"${ADMIN_PASSWORD}"'), ':zmQetUQSrQwdbyS1XVDwG9AsfKkgfXAd'))"; then
+    mysql -u db -h db db -e "INSERT INTO admin_role(parent_id, tree_level, sort_order, role_type, user_id, role_name) VALUES (1, 2, 0, 'U',(SELECT user_id FROM admin_user WHERE username = '"${ADMIN_USER}"'),'"${ADMIN_FIRSTNAME}"')"
+    echo "The account "$ADMIN_USER" has been created."
+  else
+    echo "The account "$ADMIN_USER" exists. Use the Update action instead if you want to change the password."
+  fi
+else
+  exit 1
+fi


### PR DESCRIPTION
The ```ddev config``` command doesn't create the administrator account, as a consequence the Backend cannot be accessed. In this case, either a query is run in the MySQL prompt getting the console ```ddev mysql```, or the same query is run in phpMyAdmin interface ```ddev launch -p```, so that data is inserted into the **admin_role** and **admin_user** tables. I raised this issue, but nothing was done about it. 

This PR solves this issue and it adds a new DDEV command to create/update the administrator account. Usage is very simple, in terminal use this command ```ddev openmage-admin```, choose your action then answer to the questions.

I use the **update** or just **u** action when I wanted to change the initial password, in my test environment it is much easier to enter 123, instead of a string of at least 14 characters. I didn't use the **create** or **c** action because I didn't need it, but it works. I deleted the records from the two previously mentioned tables and the script created the account. I also took in consideration the fact that the account exists.

This PR comes as an accessory to the one created here #3248 and through which OpenMage w/o Sample Data can be installed.

PS - I am not an expert in Bash script, this PR can be modified to cover even more cases, errors, etc. In creating the password I used a string of characters, I didn't spend time to generate a random one. If anyone knows how to do this, please change that part.