### PR TITLE
Row click issue in widget grid

### DIFF
--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -852,10 +852,10 @@ serializerController.prototype = {
         this.rowInit(this.grid, row);
     },
     rowClick : function(grid, event) {
-        var trElement = Event.findElement(event, 'tr');
+        var drElement = Event.findElement(event, 'td');
         var isInput   = Event.element(event).tagName == 'INPUT';
-        if(trElement){
-            var checkbox = Element.select(trElement, 'input');
+        if(tdElement){
+            var checkbox = Element.select(tdElement, 'input');
             if(checkbox[0] && !checkbox[0].disabled){
                 var checked = isInput ? checkbox[0].checked : !checkbox[0].checked;
                 this.grid.setCheckboxChecked(checkbox[0], checked);


### PR DESCRIPTION
When you add/remove/set position in the **Related Products / Up-sells / Cross-sells** grids, you may face an important issue without realizing it. As the grid functionality was thought by the Magento team, when you click on a row, regardless of the position where the mouse pointer is, the row will be checked or unchecked. As soon as you press any of the [Save] buttons, products may appear or disappear in the grid by mistake. I faced this issue many times when I was editing the position and I didn't click exactly in the box but a little next to it.

![related](https://github.com/ADDISON74/magento-lts/assets/8360474/305af4d0-fc2b-4164-89c3-3127ca052106)

This PR solves the issue and limits the row click strictly to the grid cell where the checkbox is (the first column). Unlike the Products grid, where the box must be checked strictly in the square, otherwise the product editing page is loaded, this modification is more permissive and the click can be in the entire cell where the box is located (td element).